### PR TITLE
fix: get_room_at_pos crashes when called in dungeon_done_generating signal "Trying to return a previously freed instance" (fixes majikayogames/SimpleDungeons#17)

### DIFF
--- a/addons/SimpleDungeons/DungeonGenerator3D.gd
+++ b/addons/SimpleDungeons/DungeonGenerator3D.gd
@@ -296,11 +296,25 @@ func _finalize_rooms(ready_callback = null) -> void:
 	if not rooms_container.is_inside_tree():
 		add_child(rooms_container)
 	rooms_container.owner = self.owner
+	
+	_quick_room_check_dict = {}
+	_quick_corridors_check_dict = {}
+	
 	for room in _rooms_placed.slice(0):
 		_rooms_placed.erase(room)
 		var unvirtualized = room.unvirtualize_and_free_clone_if_needed(rooms_container)
 		unvirtualized.owner = self.owner
 		_rooms_placed.push_back(unvirtualized)
+		
+		var aabbi = unvirtualized.get_grid_aabbi(false)
+		for x in aabbi.size.x: for y in aabbi.size.y: for z in aabbi.size.z:
+			_quick_room_check_dict[aabbi.position + Vector3i(x, y, z)] = unvirtualized
+			
+	for preplaced_room in get_preplaced_rooms():
+		var aabbi = preplaced_room.get_grid_aabbi(false)
+		for x in aabbi.size.x: for y in aabbi.size.y: for z in aabbi.size.z:
+			_quick_room_check_dict[aabbi.position + Vector3i(x, y, z)] = preplaced_room
+			
 	for room in room_instances:
 		if room and is_instance_valid(room):
 			room.queue_free()
@@ -340,8 +354,6 @@ func _emit_done_signals():
 	for preplaced_room in find_children("*", "DungeonRoom3D", false):
 		preplaced_room.dungeon_done_generating.emit()
 	print("DungeonGenerator3D finished generating.")
-	for room in room_instances:
-		room.queue_free()
 	done_generating.emit()
 
 func _emit_failed_signal(): # So I can call_deferred
@@ -851,7 +863,12 @@ func get_room_at_pos(grid_pos : Vector3i) -> DungeonRoom3D:
 	if stage > BuildStage.CONNECT_ROOMS:
 		 # Can use these vars for speedup if past the connect rooms stage where we set them
 		var quick_check = _quick_room_check_dict.get(grid_pos)
-		return quick_check if quick_check else _quick_corridors_check_dict.get(grid_pos)
+		if quick_check and is_instance_valid(quick_check):
+			return quick_check
+		var quick_corridor = _quick_corridors_check_dict.get(grid_pos)
+		if quick_corridor and is_instance_valid(quick_corridor):
+			return quick_corridor
+		return null
 	for room in get_all_placed_and_preplaced_rooms():
 		if room.get_grid_aabbi(false).contains_point(grid_pos):
 			return room


### PR DESCRIPTION
Fixes #17 

## The Issue
The error `DungeonGenerator3D.get_room_at_pos: Trying to return a previously freed instance` occurred during the dungeon generation's finalization phase. This happened when scripts (like the door removal examples in the wiki) attempted to query room connections using `get_room_leads_to()`.

## The Cause
The `DungeonGenerator3D` uses a "virtualization" process to speed up generation:
1.  **Virtualization**: It creates lightweight clones of rooms to calculate layout and connections.
2.  **Lookup Map**: It maintains a dictionary (`_quick_room_check_dict`) mapping grid coordinates to these virtual room instances.
3.  **Unvirtualization**: When generation finishes, it deletes the virtual clones and replaces them with real scene instances.

**The Bug**: The lookup map was not being updated during unvirtualization. It continued to point to the *deleted* virtual clones. When a script asked "what room is here?", the generator returned a reference to a freed object, causing the crash.

## The Fixes

### 1. Rebuild Lookup Dictionaries
Updated `_finalize_rooms` to clear and rebuild the coordinate dictionaries (`_quick_room_check_dict` and `_quick_corridors_check_dict`) immediately after spawning the real rooms. This ensures the map points to valid, living instances.

```gdscript
# In _finalize_rooms()
_quick_room_check_dict = {}
_quick_corridors_check_dict = {}

for room in _rooms_placed.slice(0):
    # ... (unvirtualization logic) ...
    
    # Map the NEW real room to its coordinates
    var aabbi = unvirtualized.get_grid_aabbi(false)
    for x in aabbi.size.x: for y in aabbi.size.y: for z in aabbi.size.z:
        _quick_room_check_dict[aabbi.position + Vector3i(x, y, z)] = unvirtualized
```

### 2. Add Safety Checks
Updated `get_room_at_pos` to verify that an instance is valid before returning it. This prevents the generator from ever returning a freed object, even if the map were to become desynchronized again.

```gdscript
# In get_room_at_pos()
var quick_check = _quick_room_check_dict.get(grid_pos)
if quick_check and is_instance_valid(quick_check):
    return quick_check
```

### 3. Remove Redundant Cleanup
Removed a loop in `_emit_done_signals` that attempted to `queue_free()` the `room_instances` array a second time. Since `_finalize_rooms` already handles this cleanup, the second attempt was redundant and potentially dangerous.
