### PR TITLE
Add dungeon path-navigation utility (path from start to end room)

### DIFF
--- a/addons/SimpleDungeons/DungeonGenerator3D.gd
+++ b/addons/SimpleDungeons/DungeonGenerator3D.gd
@@ -296,11 +296,17 @@ func _finalize_rooms(ready_callback = null) -> void:
 	if not rooms_container.is_inside_tree():
 		add_child(rooms_container)
 	rooms_container.owner = self.owner
+	var virtual_to_real: Dictionary = {}
 	for room in _rooms_placed.slice(0):
 		_rooms_placed.erase(room)
 		var unvirtualized = room.unvirtualize_and_free_clone_if_needed(rooms_container)
 		unvirtualized.owner = self.owner
 		_rooms_placed.push_back(unvirtualized)
+		virtual_to_real[room] = unvirtualized
+	for pos in _quick_room_check_dict:
+		_quick_room_check_dict[pos] = virtual_to_real.get(_quick_room_check_dict[pos], _quick_room_check_dict[pos])
+	for pos in _quick_corridors_check_dict:
+		_quick_corridors_check_dict[pos] = virtual_to_real.get(_quick_corridors_check_dict[pos], _quick_corridors_check_dict[pos])
 	for room in room_instances:
 		if room and is_instance_valid(room):
 			room.queue_free()

--- a/navigation_demo/extra_rooms/end_room.tscn
+++ b/navigation_demo/extra_rooms/end_room.tscn
@@ -1,0 +1,48 @@
+[gd_scene format=3 uid="uid://qwifmvjveoe3"]
+
+[ext_resource type="Script" uid="uid://c8mua856s1ape" path="res://addons/SimpleDungeons/DungeonRoom3D.gd" id="1_0k746"]
+[ext_resource type="Texture2D" uid="uid://wvh1xmoax4ok" path="res://addons/SimpleDungeons/sample_assets/kenney-dark-grey-grid-cc0.png" id="2_y8cer"]
+[ext_resource type="Texture2D" uid="uid://dydd6x64uxryr" path="res://addons/SimpleDungeons/sample_assets/kenney-red-checkerboard-cc0.png" id="3_2sepe"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_57r0k"]
+albedo_texture = ExtResource("2_y8cer")
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_shrej"]
+albedo_texture = ExtResource("3_2sepe")
+
+[node name="EndRoom" type="Node3D" unique_id=1702484105]
+script = ExtResource("1_0k746")
+min_count = 1
+max_count = 1
+
+[node name="FrontDoor" type="CSGBox3D" parent="." unique_id=41470487]
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, -1.83588e-06, -2.75, -4.5)
+material_override = SubResource("StandardMaterial3D_57r0k")
+size = Vector3(5, 4, 0.5)
+
+[node name="CSGBox3D" type="CSGBox3D" parent="." unique_id=1532235071]
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, -1.44248e-06, 0, 0)
+material_override = SubResource("StandardMaterial3D_shrej")
+use_collision = true
+size = Vector3(10, 10, 10)
+
+[node name="CSGBox3D2" type="CSGBox3D" parent="CSGBox3D" unique_id=792628252]
+operation = 2
+size = Vector3(9.5, 9.5, 9.5)
+
+[node name="DOOR_F_CUT" type="CSGBox3D" parent="CSGBox3D" unique_id=1009276598]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.75, -5)
+operation = 2
+size = Vector3(2, 4, 1)
+
+[node name="DOOR_R_CUT" type="CSGBox3D" parent="CSGBox3D" unique_id=29463592]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 5, -2.75, 0)
+operation = 2
+size = Vector3(2, 4, 1)
+
+[node name="DOOR_L_CUT" type="CSGBox3D" parent="CSGBox3D" unique_id=1798275583]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -5, -2.75, 0)
+operation = 2
+size = Vector3(2, 4, 1)
+
+[node name="PlayerSpawnPoint" type="Node3D" parent="." unique_id=1000395860 groups=["player_spawn_point"]]

--- a/navigation_demo/extra_rooms/end_room.tscn
+++ b/navigation_demo/extra_rooms/end_room.tscn
@@ -44,5 +44,3 @@ size = Vector3(2, 4, 1)
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -5, -2.75, 0)
 operation = 2
 size = Vector3(2, 4, 1)
-
-[node name="PlayerSpawnPoint" type="Node3D" parent="." unique_id=1000395860 groups=["player_spawn_point"]]

--- a/navigation_demo/extra_rooms/start_room.tscn
+++ b/navigation_demo/extra_rooms/start_room.tscn
@@ -1,0 +1,48 @@
+[gd_scene format=3 uid="uid://jeqqr3ovq6w"]
+
+[ext_resource type="Script" uid="uid://c8mua856s1ape" path="res://addons/SimpleDungeons/DungeonRoom3D.gd" id="1_0k746"]
+[ext_resource type="Texture2D" uid="uid://wvh1xmoax4ok" path="res://addons/SimpleDungeons/sample_assets/kenney-dark-grey-grid-cc0.png" id="2_y8cer"]
+[ext_resource type="Texture2D" uid="uid://bwe02yta75ooa" path="res://addons/SimpleDungeons/sample_assets/kenney-green-checkerboar-cc0.png" id="3_j5hk5"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_57r0k"]
+albedo_texture = ExtResource("2_y8cer")
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_vdihx"]
+albedo_texture = ExtResource("3_j5hk5")
+
+[node name="StartRoom" type="Node3D" unique_id=52490120]
+script = ExtResource("1_0k746")
+min_count = 1
+max_count = 1
+
+[node name="FrontDoor" type="CSGBox3D" parent="." unique_id=619402681]
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, -1.83588e-06, -2.75, -4.5)
+material_override = SubResource("StandardMaterial3D_57r0k")
+size = Vector3(5, 4, 0.5)
+
+[node name="CSGBox3D" type="CSGBox3D" parent="." unique_id=2121049491]
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, -1.44248e-06, 0, 0)
+material_override = SubResource("StandardMaterial3D_vdihx")
+use_collision = true
+size = Vector3(10, 10, 10)
+
+[node name="CSGBox3D2" type="CSGBox3D" parent="CSGBox3D" unique_id=595466228]
+operation = 2
+size = Vector3(9.5, 9.5, 9.5)
+
+[node name="DOOR_F_CUT" type="CSGBox3D" parent="CSGBox3D" unique_id=1263428935]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.75, -5)
+operation = 2
+size = Vector3(2, 4, 1)
+
+[node name="DOOR_R_CUT" type="CSGBox3D" parent="CSGBox3D" unique_id=1325875988]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 5, -2.75, 0)
+operation = 2
+size = Vector3(2, 4, 1)
+
+[node name="DOOR_L_CUT" type="CSGBox3D" parent="CSGBox3D" unique_id=1210403336]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -5, -2.75, 0)
+operation = 2
+size = Vector3(2, 4, 1)
+
+[node name="PlayerSpawnPoint" type="Node3D" parent="." unique_id=237403211 groups=["player_spawn_point"]]

--- a/navigation_demo/navi_util.gd
+++ b/navigation_demo/navi_util.gd
@@ -147,12 +147,23 @@ func print_path(path: Array[DungeonRoom3D]):
 
 
 func test_pathfinding():
-	if _all_rooms.size() < 2 or not start_room or not end_room:
+	if _all_rooms.size() < 2:
 		return
-	print("Path: %s -> %s" % [start_room.name, end_room.name])
-	var path = find_path_bfs(start_room, end_room)
+	var from := start_room if start_room else _all_rooms[0] as DungeonRoom3D
+	var to   := end_room   if end_room   else _all_rooms[-1] as DungeonRoom3D
+	print("Path: %s -> %s" % [from.name, to.name])
+	var path = find_path_bfs(from, to)
 	print_path(path)
 	render_path(path)
+
+
+func set_path_depth_test(enabled: bool):
+	if _path_mesh_instance:
+		for child in _path_mesh_instance.get_children():
+			if child is MeshInstance3D:
+				var mat = child.material_override as StandardMaterial3D
+				if mat:
+					mat.no_depth_test = enabled
 
 
 func render_path(path: Array[DungeonRoom3D]):
@@ -173,8 +184,8 @@ func render_path(path: Array[DungeonRoom3D]):
 	_path_mesh_instance = container
 
 	for i in range(path.size() - 1):
-		var from := path[i].global_position     + Vector3.UP * 2.0
-		var to   := path[i + 1].global_position + Vector3.UP * 2.0
+		var from := path[i].global_position     + Vector3.UP * 0.05
+		var to   := path[i + 1].global_position + Vector3.UP * 0.05
 
 		var cyl := CylinderMesh.new()
 		cyl.top_radius    = path_tube_radius

--- a/navigation_demo/navigation_demo.gd
+++ b/navigation_demo/navigation_demo.gd
@@ -6,6 +6,8 @@ var player_scene = preload("res://FPSController/FPSController.tscn")
 
 func _ready():
 	%DungeonGenerator3D.generate(randi())
+	$GUI/PlayerButton.pressed.connect(_on_spawn_player_button_pressed)
+	$GUI/PlayerButton.pressed.connect(func(): $NavigationUtil.set_path_depth_test(false))
 
 var player
 func _on_spawn_player_button_pressed():
@@ -16,3 +18,4 @@ func _on_spawn_player_button_pressed():
 	spawn_points.pick_random().add_child(player)
 	for cam in player.find_children("*", "Camera3D"):
 		cam.current = true
+	$GUI.hide()

--- a/navigation_demo/navigation_demo.gd
+++ b/navigation_demo/navigation_demo.gd
@@ -1,0 +1,18 @@
+extends Node3D
+
+var player_scene = preload("res://FPSController/FPSController.tscn")
+
+@onready var dungeon_generator = %DungeonGenerator3D
+
+func _ready():
+	%DungeonGenerator3D.generate(randi())
+
+var player
+func _on_spawn_player_button_pressed():
+	if player and is_instance_valid(player): return
+	var spawn_points = get_tree().get_nodes_in_group("player_spawn_point")
+	if spawn_points.size() == 0: return
+	player = player_scene.instantiate()
+	spawn_points.pick_random().add_child(player)
+	for cam in player.find_children("*", "Camera3D"):
+		cam.current = true

--- a/navigation_demo/navigation_demo.tscn
+++ b/navigation_demo/navigation_demo.tscn
@@ -9,7 +9,7 @@
 [ext_resource type="PackedScene" uid="uid://qwifmvjveoe3" path="res://navigation_demo/extra_rooms/end_room.tscn" id="6_b3sdd"]
 [ext_resource type="PackedScene" uid="uid://c30fpfkorbyl6" path="res://addons/SimpleDungeons/sample_dungeons/with_dev_textures_rooms/corridor.tscn" id="6_w1n1b"]
 [ext_resource type="PackedScene" uid="uid://jeqqr3ovq6w" path="res://navigation_demo/extra_rooms/start_room.tscn" id="7_fl77q"]
-[ext_resource type="Script" uid="uid://b0jg5df82d8a3" path="res://utils/navi_util.gd" id="9_fl77q"]
+[ext_resource type="Script" uid="uid://b0jg5df82d8a3" path="res://navigation_demo/navi_util.gd" id="9_fl77q"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_qyqmu"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -62,3 +62,17 @@ script = ExtResource("9_fl77q")
 dungeon_generator = NodePath("../DungeonGenerator3D")
 start_room = NodePath("../DungeonGenerator3D/StartRoom")
 end_room = NodePath("../DungeonGenerator3D/EndRoom")
+
+[node name="GUI" type="Control" parent="." unique_id=1610691562]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 164.0
+offset_bottom = 95.0
+
+[node name="PlayerButton" type="Button" parent="GUI" unique_id=1022732669]
+layout_mode = 0
+offset_left = 4.0
+offset_top = 4.0
+offset_right = 35.0
+offset_bottom = 12.0
+text = "Spawn Player"

--- a/navigation_demo/navigation_demo.tscn
+++ b/navigation_demo/navigation_demo.tscn
@@ -1,0 +1,64 @@
+[gd_scene format=3 uid="uid://by75ktrhb12eq"]
+
+[ext_resource type="Script" uid="uid://pwbil65dvoej" path="res://navigation_demo/navigation_demo.gd" id="1_w1n1b"]
+[ext_resource type="Script" uid="uid://dfvs6fffklc1d" path="res://addons/SimpleDungeons/DungeonGenerator3D.gd" id="1_wd02n"]
+[ext_resource type="PackedScene" uid="uid://c74pq22tm4lts" path="res://addons/SimpleDungeons/sample_dungeons/with_dev_textures_rooms/bridge_room.tscn" id="3_umvx1"]
+[ext_resource type="PackedScene" uid="uid://b8bnbf7bch1s0" path="res://addons/SimpleDungeons/sample_dungeons/with_dev_textures_rooms/living_room.tscn" id="4_b3sdd"]
+[ext_resource type="Script" uid="uid://cqu7bt50llhbc" path="res://CamOrbitCenter.gd" id="4_huxu7"]
+[ext_resource type="PackedScene" uid="uid://dxmljn5pbp0b1" path="res://addons/SimpleDungeons/sample_dungeons/with_dev_textures_rooms/stair.tscn" id="5_fl77q"]
+[ext_resource type="PackedScene" uid="uid://qwifmvjveoe3" path="res://navigation_demo/extra_rooms/end_room.tscn" id="6_b3sdd"]
+[ext_resource type="PackedScene" uid="uid://c30fpfkorbyl6" path="res://addons/SimpleDungeons/sample_dungeons/with_dev_textures_rooms/corridor.tscn" id="6_w1n1b"]
+[ext_resource type="PackedScene" uid="uid://jeqqr3ovq6w" path="res://navigation_demo/extra_rooms/start_room.tscn" id="7_fl77q"]
+[ext_resource type="Script" uid="uid://b0jg5df82d8a3" path="res://utils/navi_util.gd" id="9_fl77q"]
+
+[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_qyqmu"]
+sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
+ground_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
+
+[sub_resource type="Sky" id="Sky_dscqc"]
+sky_material = SubResource("ProceduralSkyMaterial_qyqmu")
+
+[sub_resource type="Environment" id="Environment_4mo8u"]
+background_mode = 2
+sky = SubResource("Sky_dscqc")
+tonemap_mode = 2
+glow_enabled = true
+
+[node name="NavigationDemo" type="Node3D" unique_id=1493065929]
+script = ExtResource("1_w1n1b")
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="." unique_id=2038055246]
+transform = Transform3D(-0.866023, -0.433016, 0.250001, 0, 0.499998, 0.866027, -0.500003, 0.749999, -0.43301, 0, 0, 0)
+shadow_enabled = true
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="." unique_id=1523839232]
+environment = SubResource("Environment_4mo8u")
+
+[node name="DungeonGenerator3D" type="Node3D" parent="." unique_id=693491330]
+unique_name_in_owner = true
+script = ExtResource("1_wd02n")
+room_scenes = Array[PackedScene]([ExtResource("3_umvx1"), ExtResource("4_b3sdd"), ExtResource("5_fl77q")])
+corridor_room_scene = ExtResource("6_w1n1b")
+generate_on_ready = false
+heuristic_scale = 3.0
+
+[node name="EndRoom" parent="DungeonGenerator3D" unique_id=1702484105 instance=ExtResource("6_b3sdd")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -35, -45, -45)
+
+[node name="StartRoom" parent="DungeonGenerator3D" unique_id=52490120 instance=ExtResource("7_fl77q")]
+transform = Transform3D(-1, 0, -8.742278e-08, 0, 1, 0, 8.742278e-08, 0, -1, 35, 45, 35)
+
+[node name="CamOrbitCenter" type="Node3D" parent="." unique_id=130174863]
+unique_name_in_owner = true
+script = ExtResource("4_huxu7")
+auto_rotate = true
+
+[node name="Camera3D" type="Camera3D" parent="CamOrbitCenter" unique_id=106460421]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 152)
+
+[node name="NavigationUtil" type="Node3D" parent="." unique_id=1080603083 node_paths=PackedStringArray("dungeon_generator", "start_room", "end_room")]
+script = ExtResource("9_fl77q")
+dungeon_generator = NodePath("../DungeonGenerator3D")
+start_room = NodePath("../DungeonGenerator3D/StartRoom")
+end_room = NodePath("../DungeonGenerator3D/EndRoom")

--- a/utils/navi_util.gd
+++ b/utils/navi_util.gd
@@ -1,0 +1,264 @@
+extends Node3D
+
+@export var dungeon_generator: DungeonGenerator3D
+@export var start_room: DungeonRoom3D
+@export var end_room: DungeonRoom3D
+
+
+
+var room_neighbors: Dictionary = {}  # { room: [neighbors] }
+var rooms_by_floor: Dictionary = {}  # { y_level: [rooms_on_floor] }
+
+# Canonical room list — real scene nodes from find_children, used as stable dict keys.
+# get_all_placed_and_preplaced_rooms() / get_room_at_pos() may return stale virtual instances
+# after finalization, so we normalize all references through this name→room lookup.
+var _all_rooms: Array = []
+var _room_by_name: Dictionary = {}  # { StringName: DungeonRoom3D }
+
+var _path_mesh_instance: Node3D = null
+
+func _ready():
+	dungeon_generator.done_generating.connect(_on_dungeon_generated)
+
+func _on_dungeon_generated():
+	print("\n========== NAVIGATION SYSTEM ==========\n")
+
+	build_neighbor_graph()
+	print_graph_ascii()
+	test_pathfinding()
+
+#######################
+## STEP 1: BUILD GRAPH
+#######################
+
+func build_neighbor_graph():
+	"""Build room adjacency graph using scene-tree nodes as canonical references."""
+	room_neighbors.clear()
+	rooms_by_floor.clear()
+	_room_by_name.clear()
+
+	# find_children returns the actual spawned scene nodes, unlike
+	# get_all_placed_and_preplaced_rooms() which may still hold stale virtual instances
+	# that were queue_freed during finalization but not yet replaced in the quick lookup dicts.
+	_all_rooms = dungeon_generator.find_children("*", "DungeonRoom3D", true)
+
+	for room in _all_rooms:
+		_room_by_name[room.name] = room
+		room_neighbors[room] = []
+		var floor_y = room.get_grid_pos().y
+		if not rooms_by_floor.has(floor_y):
+			rooms_by_floor[floor_y] = []
+		rooms_by_floor[floor_y].append(room)
+
+	for room in _all_rooms:
+		for door in room.get_doors():
+			var connected = door.get_room_leads_to()
+			if connected == null:
+				continue
+			# Normalize: connected may be a stale virtual — look up by name to get the real node
+			var canonical: DungeonRoom3D = _room_by_name.get(connected.name)
+			if canonical and canonical not in room_neighbors[room]:
+				room_neighbors[room].append(canonical)
+
+	print("Graph built: %d rooms, %d floors" % [_all_rooms.size(), rooms_by_floor.size()])
+
+func _canonical(room: DungeonRoom3D) -> DungeonRoom3D:
+	"""Return the canonical scene-node reference for a room, resolving stale virtuals by name."""
+	if room == null:
+		return null
+	return _room_by_name.get(room.name, room)
+
+func print_graph_ascii():
+	"""Print room graph as ASCII."""
+	print("\nROOM GRAPH:")
+	print("-".repeat(60))
+
+	for room in room_neighbors.keys():
+		var neighbors = room_neighbors[room]
+		var room_pos = room.get_grid_pos()
+		var neighbor_names = neighbors.map(func(n): return n.name)
+		print("  [%s] @ (%d,%d,%d) -> %s" % [room.name, room_pos.x, room_pos.y, room_pos.z, neighbor_names])
+
+	print("\nFLOORS:")
+	for floor_y in rooms_by_floor.keys():
+		var room_names = rooms_by_floor[floor_y].map(func(r): return r.name)
+		print("  Floor %d: %s" % [floor_y, room_names])
+
+	print("-".repeat(60) + "\n")
+
+#######################
+## STEP 2: PATHFINDING
+#######################
+
+func find_path_bfs(start: DungeonRoom3D = null, end: DungeonRoom3D = null) -> Array[DungeonRoom3D]:
+	"""BFS shortest path between two rooms.
+	If start or end are null, defaults to first and last rooms in the dungeon."""
+
+	if _all_rooms.is_empty():
+		return []
+	var from := _canonical(start) if start else _all_rooms[0] as DungeonRoom3D
+	var to   := _canonical(end)   if end   else _all_rooms[-1] as DungeonRoom3D
+
+	if from == to:
+		return [from]
+
+	var queue: Array = [[from]]
+	var visited: Dictionary = { from: true }
+
+	while queue.size() > 0:
+		var path: Array = queue.pop_front()
+		var current: DungeonRoom3D = path[-1]
+
+		for neighbor in room_neighbors.get(current, []):
+			if neighbor == to:
+				path.append(neighbor)
+				var result: Array[DungeonRoom3D] = []
+				result.assign(path)
+				return result
+
+			if not visited.get(neighbor, false):
+				visited[neighbor] = true
+				var new_path = path.duplicate()
+				new_path.append(neighbor)
+				queue.append(new_path)
+
+	return []
+
+func find_path_from_voxels(start_voxel: Vector3, end_voxel: Vector3) -> Array[DungeonRoom3D]:
+	"""Find room path between two world-space positions.
+	Handles multi-floor dungeons by routing through stair rooms."""
+
+	var start_grid = Vector3i((start_voxel / dungeon_generator.voxel_scale).floor())
+	var end_grid   = Vector3i((end_voxel   / dungeon_generator.voxel_scale).floor())
+
+	var from := _canonical(dungeon_generator.get_room_at_pos(start_grid))
+	var to   := _canonical(dungeon_generator.get_room_at_pos(end_grid))
+
+	if from == null:
+		push_warning("Start voxel not in any room!")
+		return []
+	if to == null:
+		push_warning("End voxel not in any room!")
+		return []
+
+	print("Finding path from %s to %s" % [from.name, to.name])
+
+	var start_floor = from.get_grid_pos().y
+	var end_floor   = to.get_grid_pos().y
+
+	if start_floor != end_floor:
+		print("  (Different floors: %d -> %d)" % [start_floor, end_floor])
+		var staircase = find_nearest_staircase(from, end_floor)
+		if staircase == null:
+			push_warning("No staircase found connecting floor %d to floor %d!" % [start_floor, end_floor])
+			return []
+		var path_to_stairs   = find_path_bfs(from, staircase)
+		var path_from_stairs = find_path_bfs(staircase, to)
+		var result: Array[DungeonRoom3D] = []
+		result.assign(path_to_stairs.slice(0, -1) + path_from_stairs)
+		return result
+
+	return find_path_bfs(from, to)
+
+func find_nearest_staircase(current_room: DungeonRoom3D, target_floor: int) -> DungeonRoom3D:
+	"""BFS to find the nearest stair room that connects to target_floor."""
+
+	var queue: Array = [current_room]
+	var visited: Dictionary = { current_room: true }
+
+	while queue.size() > 0:
+		var room: DungeonRoom3D = queue.pop_front()
+
+		var door_floors: Dictionary = {}
+		for door in room.get_doors():
+			door_floors[door.exit_pos_grid.y] = true
+
+		if door_floors.size() > 1 and target_floor in door_floors:
+			return room
+
+		for neighbor in room_neighbors.get(room, []):
+			if not visited.get(neighbor, false):
+				visited[neighbor] = true
+				queue.append(neighbor)
+
+	return null
+
+func print_path(path: Array[DungeonRoom3D]):
+	"""Pretty-print a path."""
+	if path.is_empty():
+		print("  No path found!\n")
+		return
+
+	print("  Path found (%d rooms):" % path.size())
+	for i in range(path.size()):
+		var room = path[i]
+		var pos = room.get_grid_pos()
+		var marker = "->" if i < path.size() - 1 else "[END]"
+		print("    %d. %s @ (%d,%d,%d) %s" % [i + 1, room.name, pos.x, pos.y, pos.z, marker])
+	print()
+
+#######################
+## TESTING
+#######################
+
+func test_pathfinding():
+	"""Test pathfinding with first/last rooms, cross-floor, and exported start/end."""
+
+	if _all_rooms.size() < 2:
+		print("Not enough rooms to test pathfinding\n")
+		return
+
+	if start_room and end_room:
+		print("Pathing from start_room -> end_room (%s -> %s)" % [start_room.name, end_room.name])
+		var path = find_path_bfs(start_room, end_room)
+		print_path(path)
+		render_path(path)
+
+
+@export var path_tube_radius: float = 0.15
+
+func render_path(path: Array[DungeonRoom3D]):
+	"""Draw the path as thick tubes between room centres using CylinderMesh per segment."""
+
+	if _path_mesh_instance:
+		_path_mesh_instance.queue_free()
+		_path_mesh_instance = null
+
+	if path.size() < 2:
+		return
+
+	var mat := StandardMaterial3D.new()
+	mat.albedo_color = Color.BLACK
+	mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	mat.no_depth_test = true
+
+	var container := Node3D.new()
+	add_child(container)
+	_path_mesh_instance = container
+
+	for i in range(path.size() - 1):
+		var from := path[i].global_position     + Vector3.UP * 2.0
+		var to   := path[i + 1].global_position + Vector3.UP * 2.0
+
+		var cyl := CylinderMesh.new()
+		cyl.top_radius    = path_tube_radius
+		cyl.bottom_radius = path_tube_radius
+		cyl.height        = from.distance_to(to)
+
+		var inst := MeshInstance3D.new()
+		inst.mesh              = cyl
+		inst.material_override = mat
+		container.add_child(inst)
+
+		# Align the cylinder's Y axis with the segment direction
+		var y_axis := (to - from).normalized()
+		var x_axis := Vector3.UP.cross(y_axis)
+		if x_axis.length_squared() < 0.001:
+			x_axis = Vector3.RIGHT.cross(y_axis)
+		x_axis = x_axis.normalized()
+		var z_axis := x_axis.cross(y_axis).normalized()
+
+		inst.global_transform = Transform3D(
+			Basis(x_axis, y_axis, z_axis),
+			(from + to) * 0.5
+		)

--- a/utils/navi_util.gd
+++ b/utils/navi_util.gd
@@ -3,43 +3,33 @@ extends Node3D
 @export var dungeon_generator: DungeonGenerator3D
 @export var start_room: DungeonRoom3D
 @export var end_room: DungeonRoom3D
+@export var path_tube_radius: float = 0.15
 
+var room_neighbors: Dictionary = {}
+var rooms_by_floor: Dictionary = {}
 
-
-var room_neighbors: Dictionary = {}  # { room: [neighbors] }
-var rooms_by_floor: Dictionary = {}  # { y_level: [rooms_on_floor] }
-
-# Canonical room list — real scene nodes from find_children, used as stable dict keys.
-# get_all_placed_and_preplaced_rooms() / get_room_at_pos() may return stale virtual instances
-# after finalization, so we normalize all references through this name→room lookup.
 var _all_rooms: Array = []
-var _room_by_name: Dictionary = {}  # { StringName: DungeonRoom3D }
-
+var _room_by_name: Dictionary = {}
 var _path_mesh_instance: Node3D = null
+
 
 func _ready():
 	dungeon_generator.done_generating.connect(_on_dungeon_generated)
 
-func _on_dungeon_generated():
-	print("\n========== NAVIGATION SYSTEM ==========\n")
 
+func _on_dungeon_generated():
 	build_neighbor_graph()
 	print_graph_ascii()
 	test_pathfinding()
 
-#######################
-## STEP 1: BUILD GRAPH
-#######################
 
 func build_neighbor_graph():
-	"""Build room adjacency graph using scene-tree nodes as canonical references."""
 	room_neighbors.clear()
 	rooms_by_floor.clear()
 	_room_by_name.clear()
 
-	# find_children returns the actual spawned scene nodes, unlike
-	# get_all_placed_and_preplaced_rooms() which may still hold stale virtual instances
-	# that were queue_freed during finalization but not yet replaced in the quick lookup dicts.
+	# Use find_children so we get real scene nodes — get_all_placed_and_preplaced_rooms()
+	# can return stale virtual instances after finalization
 	_all_rooms = dungeon_generator.find_children("*", "DungeonRoom3D", true)
 
 	for room in _all_rooms:
@@ -55,47 +45,37 @@ func build_neighbor_graph():
 			var connected = door.get_room_leads_to()
 			if connected == null:
 				continue
-			# Normalize: connected may be a stale virtual — look up by name to get the real node
 			var canonical: DungeonRoom3D = _room_by_name.get(connected.name)
 			if canonical and canonical not in room_neighbors[room]:
 				room_neighbors[room].append(canonical)
 
-	print("Graph built: %d rooms, %d floors" % [_all_rooms.size(), rooms_by_floor.size()])
+	print("Nav graph: %d rooms, %d floors" % [_all_rooms.size(), rooms_by_floor.size()])
+
 
 func _canonical(room: DungeonRoom3D) -> DungeonRoom3D:
-	"""Return the canonical scene-node reference for a room, resolving stale virtuals by name."""
 	if room == null:
 		return null
 	return _room_by_name.get(room.name, room)
 
+
 func print_graph_ascii():
-	"""Print room graph as ASCII."""
 	print("\nROOM GRAPH:")
 	print("-".repeat(60))
-
 	for room in room_neighbors.keys():
-		var neighbors = room_neighbors[room]
-		var room_pos = room.get_grid_pos()
-		var neighbor_names = neighbors.map(func(n): return n.name)
-		print("  [%s] @ (%d,%d,%d) -> %s" % [room.name, room_pos.x, room_pos.y, room_pos.z, neighbor_names])
-
+		var pos = room.get_grid_pos()
+		var names = room_neighbors[room].map(func(n): return n.name)
+		print("  [%s] @ (%d,%d,%d) -> %s" % [room.name, pos.x, pos.y, pos.z, names])
 	print("\nFLOORS:")
 	for floor_y in rooms_by_floor.keys():
-		var room_names = rooms_by_floor[floor_y].map(func(r): return r.name)
-		print("  Floor %d: %s" % [floor_y, room_names])
-
+		var names = rooms_by_floor[floor_y].map(func(r): return r.name)
+		print("  Floor %d: %s" % [floor_y, names])
 	print("-".repeat(60) + "\n")
 
-#######################
-## STEP 2: PATHFINDING
-#######################
 
 func find_path_bfs(start: DungeonRoom3D = null, end: DungeonRoom3D = null) -> Array[DungeonRoom3D]:
-	"""BFS shortest path between two rooms.
-	If start or end are null, defaults to first and last rooms in the dungeon."""
-
 	if _all_rooms.is_empty():
 		return []
+
 	var from := _canonical(start) if start else _all_rooms[0] as DungeonRoom3D
 	var to   := _canonical(end)   if end   else _all_rooms[-1] as DungeonRoom3D
 
@@ -115,7 +95,6 @@ func find_path_bfs(start: DungeonRoom3D = null, end: DungeonRoom3D = null) -> Ar
 				var result: Array[DungeonRoom3D] = []
 				result.assign(path)
 				return result
-
 			if not visited.get(neighbor, false):
 				visited[neighbor] = true
 				var new_path = path.duplicate()
@@ -124,47 +103,33 @@ func find_path_bfs(start: DungeonRoom3D = null, end: DungeonRoom3D = null) -> Ar
 
 	return []
 
+
 func find_path_from_voxels(start_voxel: Vector3, end_voxel: Vector3) -> Array[DungeonRoom3D]:
-	"""Find room path between two world-space positions.
-	Handles multi-floor dungeons by routing through stair rooms."""
+	var from := _canonical(dungeon_generator.get_room_at_pos(Vector3i((start_voxel / dungeon_generator.voxel_scale).floor())))
+	var to   := _canonical(dungeon_generator.get_room_at_pos(Vector3i((end_voxel   / dungeon_generator.voxel_scale).floor())))
 
-	var start_grid = Vector3i((start_voxel / dungeon_generator.voxel_scale).floor())
-	var end_grid   = Vector3i((end_voxel   / dungeon_generator.voxel_scale).floor())
-
-	var from := _canonical(dungeon_generator.get_room_at_pos(start_grid))
-	var to   := _canonical(dungeon_generator.get_room_at_pos(end_grid))
-
-	if from == null:
-		push_warning("Start voxel not in any room!")
+	if from == null or to == null:
+		push_warning("Voxel position not inside any room")
 		return []
-	if to == null:
-		push_warning("End voxel not in any room!")
-		return []
-
-	print("Finding path from %s to %s" % [from.name, to.name])
 
 	var start_floor = from.get_grid_pos().y
 	var end_floor   = to.get_grid_pos().y
 
 	if start_floor != end_floor:
-		print("  (Different floors: %d -> %d)" % [start_floor, end_floor])
 		var staircase = find_nearest_staircase(from, end_floor)
 		if staircase == null:
-			push_warning("No staircase found connecting floor %d to floor %d!" % [start_floor, end_floor])
+			push_warning("No staircase connecting floor %d to %d" % [start_floor, end_floor])
 			return []
-		var path_to_stairs   = find_path_bfs(from, staircase)
-		var path_from_stairs = find_path_bfs(staircase, to)
 		var result: Array[DungeonRoom3D] = []
-		result.assign(path_to_stairs.slice(0, -1) + path_from_stairs)
+		result.assign(find_path_bfs(from, staircase).slice(0, -1) + find_path_bfs(staircase, to))
 		return result
 
 	return find_path_bfs(from, to)
 
-func find_nearest_staircase(current_room: DungeonRoom3D, target_floor: int) -> DungeonRoom3D:
-	"""BFS to find the nearest stair room that connects to target_floor."""
 
-	var queue: Array = [current_room]
-	var visited: Dictionary = { current_room: true }
+func find_nearest_staircase(from: DungeonRoom3D, target_floor: int) -> DungeonRoom3D:
+	var queue: Array = [from]
+	var visited: Dictionary = { from: true }
 
 	while queue.size() > 0:
 		var room: DungeonRoom3D = queue.pop_front()
@@ -183,43 +148,28 @@ func find_nearest_staircase(current_room: DungeonRoom3D, target_floor: int) -> D
 
 	return null
 
+
 func print_path(path: Array[DungeonRoom3D]):
-	"""Pretty-print a path."""
 	if path.is_empty():
-		print("  No path found!\n")
+		print("  No path found")
 		return
-
-	print("  Path found (%d rooms):" % path.size())
+	print("  Path (%d rooms):" % path.size())
 	for i in range(path.size()):
-		var room = path[i]
-		var pos = room.get_grid_pos()
+		var pos = path[i].get_grid_pos()
 		var marker = "->" if i < path.size() - 1 else "[END]"
-		print("    %d. %s @ (%d,%d,%d) %s" % [i + 1, room.name, pos.x, pos.y, pos.z, marker])
-	print()
+		print("    %d. %s @ (%d,%d,%d) %s" % [i + 1, path[i].name, pos.x, pos.y, pos.z, marker])
 
-#######################
-## TESTING
-#######################
 
 func test_pathfinding():
-	"""Test pathfinding with first/last rooms, cross-floor, and exported start/end."""
-
-	if _all_rooms.size() < 2:
-		print("Not enough rooms to test pathfinding\n")
+	if _all_rooms.size() < 2 or not start_room or not end_room:
 		return
+	print("Path: %s -> %s" % [start_room.name, end_room.name])
+	var path = find_path_bfs(start_room, end_room)
+	print_path(path)
+	render_path(path)
 
-	if start_room and end_room:
-		print("Pathing from start_room -> end_room (%s -> %s)" % [start_room.name, end_room.name])
-		var path = find_path_bfs(start_room, end_room)
-		print_path(path)
-		render_path(path)
-
-
-@export var path_tube_radius: float = 0.15
 
 func render_path(path: Array[DungeonRoom3D]):
-	"""Draw the path as thick tubes between room centres using CylinderMesh per segment."""
-
 	if _path_mesh_instance:
 		_path_mesh_instance.queue_free()
 		_path_mesh_instance = null
@@ -250,15 +200,13 @@ func render_path(path: Array[DungeonRoom3D]):
 		inst.material_override = mat
 		container.add_child(inst)
 
-		# Align the cylinder's Y axis with the segment direction
 		var y_axis := (to - from).normalized()
 		var x_axis := Vector3.UP.cross(y_axis)
 		if x_axis.length_squared() < 0.001:
 			x_axis = Vector3.RIGHT.cross(y_axis)
 		x_axis = x_axis.normalized()
-		var z_axis := x_axis.cross(y_axis).normalized()
 
 		inst.global_transform = Transform3D(
-			Basis(x_axis, y_axis, z_axis),
+			Basis(x_axis, y_axis, x_axis.cross(y_axis).normalized()),
 			(from + to) * 0.5
 		)

--- a/utils/navi_util.gd
+++ b/utils/navi_util.gd
@@ -9,7 +9,6 @@ var room_neighbors: Dictionary = {}
 var rooms_by_floor: Dictionary = {}
 
 var _all_rooms: Array = []
-var _room_by_name: Dictionary = {}
 var _path_mesh_instance: Node3D = null
 
 
@@ -26,14 +25,10 @@ func _on_dungeon_generated():
 func build_neighbor_graph():
 	room_neighbors.clear()
 	rooms_by_floor.clear()
-	_room_by_name.clear()
 
-	# Use find_children so we get real scene nodes — get_all_placed_and_preplaced_rooms()
-	# can return stale virtual instances after finalization
-	_all_rooms = dungeon_generator.find_children("*", "DungeonRoom3D", true)
+	_all_rooms = dungeon_generator.get_all_placed_and_preplaced_rooms()
 
 	for room in _all_rooms:
-		_room_by_name[room.name] = room
 		room_neighbors[room] = []
 		var floor_y = room.get_grid_pos().y
 		if not rooms_by_floor.has(floor_y):
@@ -43,19 +38,10 @@ func build_neighbor_graph():
 	for room in _all_rooms:
 		for door in room.get_doors():
 			var connected = door.get_room_leads_to()
-			if connected == null:
-				continue
-			var canonical: DungeonRoom3D = _room_by_name.get(connected.name)
-			if canonical and canonical not in room_neighbors[room]:
-				room_neighbors[room].append(canonical)
+			if connected and connected not in room_neighbors[room]:
+				room_neighbors[room].append(connected)
 
 	print("Nav graph: %d rooms, %d floors" % [_all_rooms.size(), rooms_by_floor.size()])
-
-
-func _canonical(room: DungeonRoom3D) -> DungeonRoom3D:
-	if room == null:
-		return null
-	return _room_by_name.get(room.name, room)
 
 
 func print_graph_ascii():
@@ -76,8 +62,8 @@ func find_path_bfs(start: DungeonRoom3D = null, end: DungeonRoom3D = null) -> Ar
 	if _all_rooms.is_empty():
 		return []
 
-	var from := _canonical(start) if start else _all_rooms[0] as DungeonRoom3D
-	var to   := _canonical(end)   if end   else _all_rooms[-1] as DungeonRoom3D
+	var from := start if start else _all_rooms[0] as DungeonRoom3D
+	var to   := end   if end   else _all_rooms[-1] as DungeonRoom3D
 
 	if from == to:
 		return [from]
@@ -105,8 +91,8 @@ func find_path_bfs(start: DungeonRoom3D = null, end: DungeonRoom3D = null) -> Ar
 
 
 func find_path_from_voxels(start_voxel: Vector3, end_voxel: Vector3) -> Array[DungeonRoom3D]:
-	var from := _canonical(dungeon_generator.get_room_at_pos(Vector3i((start_voxel / dungeon_generator.voxel_scale).floor())))
-	var to   := _canonical(dungeon_generator.get_room_at_pos(Vector3i((end_voxel   / dungeon_generator.voxel_scale).floor())))
+	var from := dungeon_generator.get_room_at_pos(Vector3i((start_voxel / dungeon_generator.voxel_scale).floor()))
+	var to   := dungeon_generator.get_room_at_pos(Vector3i((end_voxel   / dungeon_generator.voxel_scale).floor()))
 
 	if from == null or to == null:
 		push_warning("Voxel position not inside any room")


### PR DESCRIPTION
navi_util.gd  builds a room adjacency graph after dungeon generation and provides BFS pathfinding between rooms

Step1:  Builds neighbor graph via door connections after done_generating :
```
[EndRoom] @ (1,0,0) -> [&"Corridor_13", &"Corridor_110", &"Corridor_115"]
[Corridor_13] @ (1,0,1) -> [&"Corridor_14", &"Corridor_111", &"Corridor_116", &"EndRoom"]
[Corridor_14] @ (1,0,2) -> [&"Corridor_15", &"Corridor_112", &"Corridor_117", &"Corridor_13"]
...
```
Step2:  BFS pathfinding between any two rooms (If room not on current floor, BFS to nearest staircase)
Step3:  render_path visualizes the path as a tube


<img width="576" height="322" alt="Screenshot 2026-03-08 at 10 23 07 pm" src="https://github.com/user-attachments/assets/26837b2b-4c9e-4e5c-9d1d-e75973c0fa82" />
<img width="562" height="319" alt="Screenshot 2026-03-08 at 10 23 01 pm" src="https://github.com/user-attachments/assets/06713df8-69a2-4937-b79f-c83e06f02e5b" />




NOTE: DungeonGenerator3D.gd was touched to fix a bug with old stale enteires inside `_quick_room_check_dict` (I kept getting some old rooms?)


